### PR TITLE
Add experiment (Put, takes, steals)

### DIFF
--- a/src/main/java/org/mx/unam/imate/concurrent/algorithms/experiments/App.java
+++ b/src/main/java/org/mx/unam/imate/concurrent/algorithms/experiments/App.java
@@ -62,6 +62,7 @@ public class App {
     private static final String STEAL_TIME = "stealTime";
     private static final String PUT_STEALS = "putSteals";
     private static final String PUT_TAKES = "putTakes";
+    private static final String PUTS_TAKES_STEALS = "putsTakesSteals";
     private static final String ALGORITHMS = "algorithms";
 
     private final JSONObject spanningTreeOptions;
@@ -69,12 +70,16 @@ public class App {
     private final boolean putSteals;
     private final boolean putTakes;
     private final boolean spanningTree;
+    private final boolean putsTakesSteals;
+    private final JSONObject ptsOptions;
 
     public App(JSONObject object) {
         this.spanningTree = object.has(SPANNING_TREE_OPTIONS);
         this.spanningTreeOptions = getOptionalValueJSONObj(object, SPANNING_TREE_OPTIONS);
         this.putSteals = getOptionalValueBool(object, PUT_STEALS);
         this.putTakes = getOptionalValueBool(object, PUT_TAKES);
+        this.putsTakesSteals = object.has(PUTS_TAKES_STEALS);
+        this.ptsOptions = getOptionalValueJSONObj(object, PUTS_TAKES_STEALS);
         this.types = processJSONArray(object.getJSONArray(ALGORITHMS));
     }
 
@@ -120,6 +125,17 @@ public class App {
             Experiments exp = new Experiments();
             System.out.println(header);
             exp.putTakes(types);
+        }
+        if (putsTakesSteals) {
+            String header
+                    = "============================================\n"
+                    + "= generating experiment puts-takes-steals  =\n"
+                    + "============================================\n";
+            Experiments exp = new Experiments();
+            System.out.println(header);
+            int workers = ptsOptions.getInt("workers");
+            int stealers = ptsOptions.getInt("stealers");
+            exp.putTakesSteals(types, workers, stealers);
         }
         if (spanningTree) {
             String header

--- a/src/main/java/org/mx/unam/imate/concurrent/algorithms/experiments/Experiments.java
+++ b/src/main/java/org/mx/unam/imate/concurrent/algorithms/experiments/Experiments.java
@@ -1,6 +1,8 @@
 package org.mx.unam.imate.concurrent.algorithms.experiments;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -15,6 +17,13 @@ import org.mx.unam.imate.concurrent.algorithms.utils.WorkStealingUtils;
  */
 public class Experiments {
 
+    private final Random random = new Random(System.nanoTime());
+
+    private boolean isOurWS(AlgorithmsType type) {
+        return type == AlgorithmsType.WS_NC_MULT || type == AlgorithmsType.B_WS_NC_MULT
+                || type == AlgorithmsType.NBWSMULT_FIFO || type == AlgorithmsType.B_NBWSMULT_FIFO;
+    }
+
     public JSONArray putSteals(List<AlgorithmsType> types) {
         JSONArray results = new JSONArray();
         types.forEach((type) -> {
@@ -23,8 +32,7 @@ public class Experiments {
             long putTime;
             long stealTime_;
             long time;
-            if (type == AlgorithmsType.WS_NC_MULT || type == AlgorithmsType.B_WS_NC_MULT
-                    || type == AlgorithmsType.NBWSMULT_FIFO || type == AlgorithmsType.B_NBWSMULT_FIFO) {
+            if (isOurWS(type)) {
                 time = System.nanoTime();
                 for (int i = 0; i < 1000000; i++) {
                     alg.put(i, 0);
@@ -72,8 +80,7 @@ public class Experiments {
             long putTime;
             long takestime;
             long time;
-            if (type == AlgorithmsType.WS_NC_MULT || type == AlgorithmsType.B_WS_NC_MULT
-                    || type == AlgorithmsType.NBWSMULT_FIFO || type == AlgorithmsType.B_NBWSMULT_FIFO) {
+            if (isOurWS(type)) {
                 time = System.nanoTime();
                 for (int i = 0; i < 1000000; i++) {
                     alg.put(i, 0);
@@ -112,6 +119,108 @@ public class Experiments {
         System.out.println(results.toString(2));
         WorkStealingUtils.saveJsonArrayToFile(results, "putsTakes.json");
         return results;
+    }
+
+    public JSONObject putTakesSteals(List<AlgorithmsType> types, int numWorkers, int numStealers) {
+        JSONObject output = new JSONObject();
+        output.put("workers", numWorkers);
+        output.put("stealers", numStealers);
+        JSONArray results = new JSONArray();
+        types.forEach(type -> {
+            JSONObject result = new JSONObject();
+            int totalThreads = numWorkers + numStealers;
+            WorkStealingStruct[] workers = new WorkStealingStruct[numWorkers];
+            int thread;
+            long putTime;
+            long takeTime = 0;
+            long stealTime = 0;
+            for (int i = 0; i < workers.length; i++) {
+                workers[i] = WorkStealingStructLookUp.getWorkStealingStruct(type, 1000000, totalThreads);
+            }
+            if (isOurWS(type)) {
+                // Hacemos puts
+                putTime = System.nanoTime();
+                for (int i = 0; i < workers.length; i++) {
+                    for (int j = 0; j < 1000000; j++) {
+                        workers[i].put(j, i);
+                    }
+                }
+                putTime = System.nanoTime() - putTime;
+                // Hacemos takes y steals
+                while (!isEmptyWorkers(true, workers)) {
+                    long aux = System.nanoTime();
+                    for (int i = 0; i < workers.length; i++) {
+                        workers[i].take(i);
+                    }
+                    aux = System.nanoTime() - aux;
+                    takeTime += aux;
+                    aux = System.nanoTime();
+                    for (int i = 0; i < numStealers; i++) {
+                        thread = pickRandomThread(numWorkers);
+                        workers[thread].steal(numWorkers + i);
+                    }
+                    aux = System.nanoTime() - aux;
+                    stealTime += aux;
+                }
+                result.put("algorithm", type.name());
+                result.put("putTime", putTime);
+                result.put("takeTime", takeTime);
+                result.put("stealTime", stealTime);
+                result.put("total", putTime + takeTime + stealTime);
+            } else {
+                putTime = System.nanoTime();
+                for (WorkStealingStruct worker : workers) {
+                    for (int i = 0; i < 1000000; i++) {
+                        worker.put(i);
+                    }
+                }
+                putTime = System.nanoTime() - putTime;
+                while (!isEmptyWorkers(false, workers)) {
+                    long aux = System.nanoTime();
+                    for (WorkStealingStruct worker : workers) {
+                        worker.take();
+                    }
+                    aux = System.nanoTime() - aux;
+                    takeTime += aux;
+                    aux = System.nanoTime();
+                    for (int i = 0; i < numStealers; i++) {
+                        thread = pickRandomThread(numWorkers);
+                        workers[thread].steal();
+                    }
+                    aux = System.nanoTime() - aux;
+                    stealTime += aux;
+                }
+                result.put("algorithm", type.name());
+                result.put("putTime", putTime);
+                result.put("takeTime", takeTime);
+                result.put("stealTime", stealTime);
+                result.put("total", putTime + takeTime + stealTime);
+            }
+            results.put(result);
+        });
+        output.put("results", results);
+        System.out.println(output.toString(2));
+        WorkStealingUtils.saveJsonObjectToFile(output, "putsTakesSteals.json");
+        return output;
+    }
+
+    int pickRandomThread(int numThreads) {
+        return random.nextInt(numThreads);
+    }
+
+    private boolean isEmptyWorkers(boolean special, WorkStealingStruct... workers) {
+        if (workers.length < 1) {
+            return true;
+        }
+        if (special) {
+            for (int i = 0; i < workers.length; i++) {
+                if (!workers[i].isEmpty(i)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return Arrays.asList(workers).stream().allMatch(worker -> worker.isEmpty());
     }
 
 }

--- a/src/main/java/org/mx/unam/imate/concurrent/algorithms/wsm/NewAlgorithm.java
+++ b/src/main/java/org/mx/unam/imate/concurrent/algorithms/wsm/NewAlgorithm.java
@@ -75,14 +75,15 @@ public class NewAlgorithm implements WorkStealingStruct {
     @Override
     public int steal(int label) {
         head[label] = Math.max(head[label], Head.get());
-        int x = Tasks.get(head[label]);
-        if (x != BOTTOM) {
-            head[label]++;
-            Head.set(head[label]);
-            return x;
-        } else {
-            return EMPTY;
+        if (head[label] < Tasks.length()) {
+            int x = Tasks.get(head[label]);
+            if (x != BOTTOM) {
+                head[label]++;
+                Head.set(head[label]);
+                return x;
+            }
         }
+        return EMPTY;
     }
 
     @Override


### PR DESCRIPTION
Add a simulation of execution of put, takes and steals for each algorithm in the application. We started doing 1,000,000 of puts and then, doing a mixture of takes and steals until the datastructure of the worker is empty. 

For the part of takes and steals, we can configure the threads as follows:

- 1 thread doing the puts and takes, 1 thread doing only steals.
- 2 or more threads doing puts and takes, 1 thread doing steals.
- 2 or more threads doing puts and takes, 2 or more threads doing steals.